### PR TITLE
Add post-specs hook in build.and.release.yml

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -1,6 +1,9 @@
 parameters:
   postCustomEnvironmentVariables: []
+  postBuild: []
   postSpecs: []
+  preSpecsReport: []
+  postPack: []
   vmImage: ''
   service_connection_nuget_org: '' 
   service_connection_github: '' 
@@ -48,6 +51,8 @@ jobs:
       arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer)'
       versioningScheme: byBuildNumber
 
+  - ${{ parameters.postBuild }}
+
   - task: DotNetCoreCLI@2
     displayName: 'Run Executable Specifications'
     inputs:
@@ -55,6 +60,8 @@ jobs:
       projects: $(SolutionToBuild)
       arguments: '-c $(BuildConfiguration) --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
       nobuild: true
+
+  - ${{ parameters.preSpecsReport }}
 
   - script: |
       dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -79,6 +86,8 @@ jobs:
       nobuild: true
       versioningScheme: byEnvVar
       versionEnvVar: GitVersion.SemVer
+
+  - ${{ parameters.postPack }}
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: Drop'

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -1,5 +1,6 @@
 parameters:
   postCustomEnvironmentVariables: []
+  postSpecs: []
   vmImage: ''
   service_connection_nuget_org: '' 
   service_connection_github: '' 
@@ -66,6 +67,8 @@ jobs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
       reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
+
+  - ${{ parameters.postSpecs }}
 
   - task: DotNetCoreCLI@2
     displayName: 'Create NuGet Packages'


### PR DESCRIPTION
Enables pipelines based on this template to add additional steps after specs have run and results published, but before packages are build.

Fixes issue: #1