### PR TITLE
Adds the ability to include additional github release assets in the f…

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -110,6 +110,7 @@ jobs:
       assets: |
           $(Build.ArtifactStagingDirectory)/**/*.nupkg
           $(Build.ArtifactStagingDirectory)/**/*.snupkg
+          $(Build.ArtifactStagingDirectory)/**/*.zip
 
   - task: NuGetCommand@2
     displayName: 'Publish to nuget.org'


### PR DESCRIPTION
Only nuget packages are included in a github release. This PR makes it possible to add additional assets to the release in the form of zip archives. Any archive that is found in the aritifact staging directory will be included in the release.