### PR TITLE
Enable conditional environment display

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -45,8 +45,10 @@ jobs:
   - ${{ parameters.postCustomEnvironmentVariables }}
 
   # Useful for debugging purposes
-  #- powershell: 'gci Env:'
-  #  displayName: 'Print Environment Variables'
+  - powershell: 'gci Env:'
+    condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
+    displayName: 'Print Environment Variables'
+
   - task: DotNetCoreCLI@2
     displayName: 'Restore & Build'
     inputs:

--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -5,7 +5,18 @@ steps:
   inputs:
     command: custom
     custom: 'tool'
-    arguments: 'install -g GitVersion.Tool --version 5.1.3'
+    arguments: 'install -g GitVersion.Tool'
 
 - script: 'dotnet-gitversion /output buildserver /nofetch' 
+  name: RunGitVersion
   displayName: 'Run GitVersion'
+
+# Starting with GitVersion 5.2.0, GitVersion includes isOutput=true on all of the variables it
+# sets, which is a breaking change. It means that these variables are no longer available with
+# the same name - they must now be qualified by the name of the task that produced them.
+# You can't turn this off, so we have to adapt to it. This just republishes them by their
+# old names, meaning anything previously depending on those names will continue to work.
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=GitVersion_SemVer]$(RunGitVersion.GitVersion.SemVer)"
+      Write-Host "##vso[task.setvariable variable=GitVersion_PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
+    displayName: 'Set Environment Variables'

--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -17,6 +17,6 @@ steps:
 # You can't turn this off, so we have to adapt to it. This just republishes them by their
 # old names, meaning anything previously depending on those names will continue to work.
 - powershell: |
-    Write-Host "##vso[task.setvariable variable=GitVersion_SemVer]$(RunGitVersion.GitVersion.SemVer)"
-    Write-Host "##vso[task.setvariable variable=GitVersion_PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
+    Write-Host "##vso[task.setvariable variable=GitVersion.SemVer]$(RunGitVersion.GitVersion.SemVer)"
+    Write-Host "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
   displayName: 'Set Environment Variables'

--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -5,7 +5,7 @@ steps:
   inputs:
     command: custom
     custom: 'tool'
-    arguments: 'install -g GitVersion.Tool'
+    arguments: 'install -g GitVersion.Tool --version 5.1.3'
 
 - script: 'dotnet-gitversion /output buildserver /nofetch' 
   displayName: 'Run GitVersion'

--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -16,7 +16,7 @@ steps:
 # the same name - they must now be qualified by the name of the task that produced them.
 # You can't turn this off, so we have to adapt to it. This just republishes them by their
 # old names, meaning anything previously depending on those names will continue to work.
-  - powershell: |
-      Write-Host "##vso[task.setvariable variable=GitVersion_SemVer]$(RunGitVersion.GitVersion.SemVer)"
-      Write-Host "##vso[task.setvariable variable=GitVersion_PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
-    displayName: 'Set Environment Variables'
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=GitVersion_SemVer]$(RunGitVersion.GitVersion.SemVer)"
+    Write-Host "##vso[task.setvariable variable=GitVersion_PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
+  displayName: 'Set Environment Variables'

--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -8,15 +8,4 @@ steps:
     arguments: 'install -g GitVersion.Tool'
 
 - script: 'dotnet-gitversion /output buildserver /nofetch' 
-  name: RunGitVersion
   displayName: 'Run GitVersion'
-
-# Starting with GitVersion 5.2.0, GitVersion includes isOutput=true on all of the variables it
-# sets, which is a breaking change. It means that these variables are no longer available with
-# the same name - they must now be qualified by the name of the task that produced them.
-# You can't turn this off, so we have to adapt to it. This just republishes them by their
-# old names, meaning anything previously depending on those names will continue to work.
-- powershell: |
-    Write-Host "##vso[task.setvariable variable=GitVersion.SemVer]$(RunGitVersion.GitVersion.SemVer)"
-    Write-Host "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
-  displayName: 'Set Environment Variables'


### PR DESCRIPTION
We've had a commented-out step that dumps the environment, since this is occasionally useful when debugging.

This change means that you no longer need to push an update to the template just to use this. Instead, by making this conditional, it becomes a feature you can opt into by setting a build variable.

Resolves #13 