### PR TITLE
Adapt to breaking change in GitVersion 5.2.0

### DIFF
--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -5,7 +5,17 @@ steps:
   inputs:
     command: custom
     custom: 'tool'
-    arguments: 'install -g GitVersion.Tool'
+    arguments: 'install -g GitVersion.Tool --version 5.2.0'
 
 - script: 'dotnet-gitversion /output buildserver /nofetch' 
   displayName: 'Run GitVersion'
+
+# Starting with GitVersion 5.2.0, GitVersion includes isOutput=true on all of the variables it
+# sets, which is a breaking change. It means that these variables are no longer available with
+# the same name - they must now be qualified by the name of the task that produced them.
+# You can't turn this off, so we have to adapt to it. This just republishes them by their
+# old names, meaning anything previously depending on those names will continue to work.
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=GitVersion.SemVer]$(RunGitVersion.GitVersion.SemVer)"
+    Write-Host "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
+  displayName: 'Publish GitVersion variables'


### PR DESCRIPTION
GitVersion no longer makes pipeline variables such as `GitVersion.SemVer` directly available. They are now all classified as task outputs, meaning you need to go through a more indirect route to read them.

This change makes the ones we were using available under their old names. It also specifies a fixed version of GitVersion so that we only upgrade when we intend to, preventing nasty surprises like this in the future.

Resolves #14