### PR TITLE
Enable .NET SDK version to be specified by parameter

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -8,6 +8,10 @@ parameters:
   service_connection_nuget_org: '' 
   service_connection_github: '' 
   solution_to_build: ''
+  # Note: temporary workround due to https://github.com/endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub/issues/22
+  netSdkVersion: '3.1.102'
+  # Revert to this once the issue has been resolved
+  netSdkVersion: '3.x'
 
 jobs:
 - job: Build
@@ -30,6 +34,8 @@ jobs:
     # Endjin.ForcePublish
   steps:
   - template: install.dotnet-global-tools.workaround.yml
+    parameters:
+      netSdkVersion: ${{ parameters.netSdkVersion }}
   - template: install-and-run-gitversion.yml
 
   - powershell: |

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -11,7 +11,7 @@ parameters:
   # Note: temporary workround due to https://github.com/endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub/issues/22
   netSdkVersion: '3.1.102'
   # Revert to this once the issue has been resolved
-  netSdkVersion: '3.x'
+  # netSdkVersion: '3.x'
 
 jobs:
 - job: Build

--- a/templates/install.dotnet-global-tools.workaround.yml
+++ b/templates/install.dotnet-global-tools.workaround.yml
@@ -1,3 +1,6 @@
+parameters:
+  netSdkVersion: '3.x'
+
 steps:
 
 - task: UseDotNet@2
@@ -11,8 +14,5 @@ steps:
   displayName: 'Install .NET Core SDK 3.x (Global Tools error workaround)'
   inputs:
     packageType: sdk
-    # Note: temporary workround due to https://github.com/endjin/Endjin.RecommendedPractices.AzureDevopsPipelines.GitHub/issues/22
-    version: 3.1.102
-    # Revert to this once the issue has been resolved
-    #version: 3.x
+    version: ${{ parameters.netSdkVersion }}
     installationPath: $(Agent.ToolsDirectory)/dotnet


### PR DESCRIPTION
Added optional netSdkVersion parameter.

Currently the default continues to be 3.1.102 (due to the bug in SpecFlow, which has been fixed in the preview of v3.3, but continues to be a problem for us until that comes out of preview and we can then update to it), but individual projects now have the option to ask for something else.

Once the SpecFlow issue has been fixed, the default will revert to 3.x, but this parameter will remain, enabling projects to opt into specific versions if required.

Resolves #26