### PR TITLE
Publish packages from the release folder.

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -176,4 +176,4 @@ jobs:
       nuGetFeedType: external
       publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
       versioningScheme: byBuildNumber
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/Packages/**/*.nupkg'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'


### PR DESCRIPTION
We should be staging artefacts into the release folder and then publishing from there.