### PR TITLE
Fix issue with 'nobuild' setting not being honoured by DotNetCoreCLI 'pack' task

### DIFF
--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -125,11 +125,14 @@ jobs:
       command: custom
       custom: pack
       projects: $(SolutionToBuild)
-      outputDir: '$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)'
-      arguments: '-c $(BuildConfiguration) --no-build --no-restore'
-      versioningScheme: byEnvVar
-      versionEnvVar: GitVersion.SemVer
-      buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
+      arguments: >
+        -c $(BuildConfiguration)
+        --no-build
+        --no-restore
+        --output $(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)
+        /p:EndjinRepositoryUrl="$(Build.Repository.Uri)"
+        /p:PackageVersion=$(GitVersion.SemVer)
+        --verbosity Detailed
 
   - ${{ parameters.postCreateNuGetPackages }}
 

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -122,10 +122,11 @@ jobs:
   - task: DotNetCoreCLI@2
     displayName: 'Create NuGet Packages'
     inputs:
-      command: 'pack'
+      command: custom
+      custom: pack
       projects: $(SolutionToBuild)
       outputDir: '$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)'
-      arguments: '--no-build --no-restore'
+      arguments: '-c $(BuildConfiguration) --no-build --no-restore'
       versioningScheme: byEnvVar
       versionEnvVar: GitVersion.SemVer
       buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -86,6 +86,8 @@ jobs:
   
   - ${{ parameters.preRunExecutableSpecs }}
 
+  # The 'test' command was not honouring the 'nobuild' setting, so now we pass is via the
+  # 'arguments' parameter which it does support. 
   - task: DotNetCoreCLI@2
     displayName: 'Run Executable Specifications'
     inputs:
@@ -119,6 +121,9 @@ jobs:
 
   - ${{ parameters.preCreateNuGetPackages }}
 
+  # We switched to using the 'custom' variant as the 'pack' command was not honoring the 'nobuild' setting, and 
+  # it also does not support the 'arguments' parameter. However, using 'custom' means we have to build the
+  # command-line ourselves.
   - task: DotNetCoreCLI@2
     displayName: 'Create NuGet Packages'
     inputs:


### PR DESCRIPTION
Example build showing this issue:
lts?buildId=6432&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=bde858e3-1ff6-5d7a-f958-9ce4fc5e6086

In the `Endjin.SemVer.DotNetApi` solution this was manifesting itself by packaging-up `v1.0.0` of `Endjin.SemVer.DotNetApi` instead of the correct version that `nupkgversion.exe` had been compiled to reference.

You can see an example `.nupkg` here:
https://www.nuget.org/packages/nupkgversion/1.0.1