### PR TITLE
New version of 'build.and.release' template that uses the 'InvokeBuild' module

### DIFF
--- a/templates/build.and.release.invokebuild.yml
+++ b/templates/build.and.release.invokebuild.yml
@@ -90,6 +90,7 @@ jobs:
     parameters:
       gitversion_semver: $(GitVersion.SemVer)
       gitversion_prerelease_tag: $(GitVersion.PreReleaseTag)
+      endjin_repository_name: $(Endjin_Repository_Name)
       preCopyNugetPackages: ${{ parameters.preCopyNugetPackages }}
       postCopyNugetPackages: ${{ parameters.postCopyNugetPackages }}
       prePublishReleaseArtifacts: ${{ parameters.prePublishReleaseArtifacts }}

--- a/templates/build.and.release.invokebuild.yml
+++ b/templates/build.and.release.invokebuild.yml
@@ -29,13 +29,13 @@ jobs:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
     # We have dependencies on the following Environment Variables:
-    # GITVERSION_PRERELEASETAG
     # BUILD_REPOSITORY_NAME
 
     # We have dependencies on the following Build Variables:
     # Endjin_Service_Connection_NuGet_Org
     # Endjin_Service_Connection_GitHub
     # Endjin.ForcePublish
+    # Endjin_Slack_ReleasesWebhookUri
   steps:
   - template: install.dotnet-global-tools.workaround.yml
     parameters:
@@ -44,7 +44,6 @@ jobs:
   - ${{ parameters.preCustomEnvironmentVariables }}
 
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))))"
       Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
     displayName: 'Set Environment Variables'
 
@@ -85,99 +84,19 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)
     displayName: Run InvokeBuild script
 
-  - ${{ parameters.preBuild }}
+  - ${{ parameters.postBuild }}
 
-  - ${{ parameters.preCopyNugetPackages }}
-
-  - task: CopyFiles@2
-    displayName: 'Copy Nuget Packages To Release Folder'
-    inputs:
-      SourceFolder: '$(Build.ArtifactStagingDirectory)'
-      Contents: |
-        Packages/**/*.nupkg
-        Packages/**/*.snupkg
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/Release/NuGet'
-
-  - ${{ parameters.postCopyNugetPackages }}
-  - ${{ parameters.prePublishReleaseArtifacts }}
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Release Artifacts'
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/Release'
-
-  - ${{ parameters.postPublishReleaseArtifacts }}
-
-  - task: NuGetToolInstaller@0
-    inputs:
-      versionSpec: '5.1.0'
-  
-  - ${{ parameters.preCreateGitHubRelease }}
-
-  - task: GithubRelease@0 
-    displayName: 'Create GitHub Release'      
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
-    inputs:
-      gitHubConnection: ${{ parameters.service_connection_github }}
-      repositoryName: $(Endjin_Repository_Name)
-      tagSource: manual
-      tag: $(GitVersion.SemVer) 
-      isPreRelease: $(Endjin_IsPreRelease)
-      assets: |
-          $(Build.ArtifactStagingDirectory)/Release/**
-
-  - ${{ parameters.postCreateGitHubRelease }}
-
-  - ${{ parameters.prePublishNugetPackages }}
-
-  - task: NuGetCommand@2
-    displayName: 'Publish to nuget.org'
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
-    inputs:
-      command: push
-      nuGetFeedType: external
-      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
-      versioningScheme: byBuildNumber
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
-
-  - ${{ parameters.postPublishNugetPackages }}
-
-  - pwsh: |
-      $body = @{
-        username = "endjin-bot"
-        icon_emoji = ":mike:"
-      }
-
-      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
-      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/Packages"
-      Write-Host $packages
-
-      $blocks = @()
-      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
-
-      $packagesText = ""
-
-      foreach ($p in $packages) {
-          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
-          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
-      }
-
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
-      $blocks += @{ type = "divider" }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
-
-      $body += @{ blocks = $blocks }
-      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
-      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
-                        -Method Post `
-                        -body (ConvertTo-Json $body -Depth 99) `
-                        -ContentType 'application/json'
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-    displayName: Send notification to Slack channel
-    env:
-      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
-      Endjin_Repository_Name: $(Endjin_Repository_Name)
-      GitVersion_SemVer: $(GitVersion.SemVer)
-      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-      
+  - template: stage.and.publish.packages.yml
+    parameters:
+      gitversion_semver: $(GitVersion.SemVer)
+      gitversion_prerelease_tag: $(GitVersion.PreReleaseTag)
+      preCopyNugetPackages: ${{ parameters.preCopyNugetPackages }}
+      postCopyNugetPackages: ${{ parameters.postCopyNugetPackages }}
+      prePublishReleaseArtifacts: ${{ parameters.prePublishReleaseArtifacts }}
+      postPublishReleaseArtifacts: ${{ parameters.postPublishReleaseArtifacts }}
+      preCreateGitHubRelease: ${{ parameters.preCreateGitHubRelease }}
+      postCreateGitHubRelease: ${{ parameters.postCreateGitHubRelease }}
+      prePublishNugetPackages: ${{ parameters.prePublishNugetPackages }}
+      postPublishNugetPackages: ${{ parameters.postPublishNugetPackages }}
+      service_connection_nuget_org: ${{ parameters.service_connection_nuget_org }}
+      service_connection_github: ${{ parameters.service_connection_github }}

--- a/templates/build.and.release.invokebuild.yml
+++ b/templates/build.and.release.invokebuild.yml
@@ -71,7 +71,7 @@ jobs:
                               -Force
       }
       if (!(Get-Module -ListAvailable InvokeBuild)) {
-        Install-Module InvokeBuild -Repository PSGallery -Force
+        Install-Module InvokeBuild -MaximumVersion 5.999.999 -Repository PSGallery -Force
       }
       Import-Module InvokeBuild
       Invoke-Build "${{ parameters.build_script }}" `

--- a/templates/build.and.release.invokebuild.yml
+++ b/templates/build.and.release.invokebuild.yml
@@ -3,16 +3,6 @@ parameters:
   postCustomEnvironmentVariables: []
   preBuild: []
   postBuild: []
-  preRunExecutableSpecs: []
-  postRunExecutableSpecs: []
-  preSpecsReport: []
-  postSpecsReport: []
-  prePublishCodeCoverageReport: []
-  postPublishCodeCoverageReport: []
-  postSpecs: []
-  preCreateNuGetPackages: []
-  postCreateNuGetPackages: []
-  postPack: []
   preCopyNugetPackages: []
   postCopyNugetPackages: []
   prePublishReleaseArtifacts: []
@@ -24,7 +14,8 @@ parameters:
   vmImage: ''
   service_connection_nuget_org: '' 
   service_connection_github: '' 
-  solution_to_build: ''
+  build_script: ''
+  build_task: '.'
   netSdkVersion: '3.x'
 
 jobs:
@@ -36,7 +27,6 @@ jobs:
     BuildConfiguration: 'Release'
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    SolutionToBuild: ${{ parameters.solution_to_build }}
 
     # We have dependencies on the following Environment Variables:
     # GITVERSION_PRERELEASETAG
@@ -50,7 +40,6 @@ jobs:
   - template: install.dotnet-global-tools.workaround.yml
     parameters:
       netSdkVersion: ${{ parameters.netSdkVersion }}
-  - template: install-and-run-gitversion.yml
 
   - ${{ parameters.preCustomEnvironmentVariables }}
 
@@ -73,85 +62,30 @@ jobs:
 
   - ${{ parameters.preBuild }}
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Restore & Build'
-    inputs:
-      command: 'build'
-      projects: $(SolutionToBuild)
-      arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer)'
-      versioningScheme: byBuildNumber
-      buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
+  # Executes the 'InvokeBuild' build script
+  - pwsh: |
+      if (!(Get-PSRepository PSGallery)) {
+        Register-PSRepository -Name "PSGallery" `
+                              –SourceLocation "https://www.powershellgallery.com/api/v2/" `
+                              -InstallationPolicy Trusted `
+                              -Force
+      }
+      if (!(Get-Module -ListAvailable InvokeBuild)) {
+        Install-Module InvokeBuild -Repository PSGallery -Force
+      }
+      Import-Module InvokeBuild
+      Invoke-Build "${{ parameters.build_script }}" `
+                   -Task "${{ parameters.build_task }}" `
+                   -Configuration "$(BuildConfiguration)" `
+                   -BuildRepositoryUri "$(Build.Repository.Uri)" `
+                   -SourcesDir "$(Build.SourcesDirectory)" `
+                   -CoverageDir "$(Build.SourcesDirectory)/CodeCoverage" `
+                   -TestReportTypes "HtmlInline_AzurePipelines;Cobertura" `
+                   -PackagesDir "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)"
+    workingDirectory: $(Build.SourcesDirectory)
+    displayName: Run InvokeBuild script
 
-  - ${{ parameters.postBuild }}
-  
-  - ${{ parameters.preRunExecutableSpecs }}
-
-  # The 'test' command was not honouring the 'nobuild' setting, so now we pass is via the
-  # 'arguments' parameter which it does support. 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Executable Specifications'
-    inputs:
-      command: 'test'
-      projects: $(SolutionToBuild)
-      arguments: '-c $(BuildConfiguration) --no-build --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
-  
-  - ${{ parameters.postRunExecutableSpecs }}
-
-  - ${{ parameters.preSpecsReport }}
-
-  - script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool
-      reportgenerator "-reports:$(Build.SourcesDirectory)/**/**/coverage.cobertura.xml" "-targetdir:$(Build.SourcesDirectory)/CodeCoverage" "-reporttypes:HtmlInline_AzurePipelines;Cobertura"
-    displayName: 'Generate Code Coverage Report'
-
-  - ${{ parameters.postSpecsReport }}
-
-  - ${{ parameters.prePublishCodeCoverageReport }}
-
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish Code Coverage Report'
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
-      reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
-
-  - ${{ parameters.postPublishCodeCoverageReport }}
-
-  - ${{ parameters.postSpecs }}
-
-  - ${{ parameters.preCreateNuGetPackages }}
-
-  # We switched to using the 'custom' variant as the 'pack' command was not honoring the 'nobuild' setting, and 
-  # it also does not support the 'arguments' parameter. However, using 'custom' means we have to build the
-  # command-line ourselves.
-  - task: DotNetCoreCLI@2
-    displayName: 'Create NuGet Packages'
-    inputs:
-      command: custom
-      custom: pack
-      projects: $(SolutionToBuild)
-      arguments: >
-        -c $(BuildConfiguration)
-        --no-build
-        --no-restore
-        --output $(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)
-        /p:EndjinRepositoryUrl="$(Build.Repository.Uri)"
-        /p:PackageVersion=$(GitVersion.SemVer)
-        --verbosity Detailed
-
-  - ${{ parameters.postCreateNuGetPackages }}
-  
-  - task: DotNetCoreCLI@2
-    displayName: 'Install nupkgversion global tool'
-    inputs:
-      command: custom
-      custom: tool
-      arguments: install -g nupkgversion
-
-  - script: 'nupkgversion "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)" https://api.nuget.org/v3/index.json'
-    displayName: 'Run nupkgversion'
-
-  - ${{ parameters.postPack }}
+  - ${{ parameters.preBuild }}
 
   - ${{ parameters.preCopyNugetPackages }}
 

--- a/templates/build.and.release.invokebuild.yml
+++ b/templates/build.and.release.invokebuild.yml
@@ -89,7 +89,7 @@ jobs:
   - template: stage.and.publish.packages.yml
     parameters:
       gitversion_semver: $(GitVersion.SemVer)
-      gitversion_prerelease_tag: $(GitVersion.PreReleaseTag)
+      gitversion_isprerelease: $[ ne(variables['GitVersion.PreReleaseTag'], '') ]
       endjin_repository_name: $(Endjin_Repository_Name)
       preCopyNugetPackages: ${{ parameters.preCopyNugetPackages }}
       postCopyNugetPackages: ${{ parameters.postCopyNugetPackages }}

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -64,6 +64,12 @@ jobs:
 
   # Executes the 'InvokeBuild' build script
   - pwsh: |
+      if (!(Get-PSRepository PSGallery)) {
+        Register-PSRepository -Name "PSGallery" `
+                              –SourceLocation "https://www.powershellgallery.com/api/v2/" `
+                              -InstallationPolicy Trusted `
+                              -Force
+      }
       if (!(Get-Module -ListAvailable InvokeBuild)) {
         Install-Module InvokeBuild -Repository PSGalley -Force
       }
@@ -77,6 +83,7 @@ jobs:
                    -TestReportTypes "HtmlInline_AzurePipelines;Cobertura" `
                    -PackagesDir "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)"
     workingDirectory: $(Build.SourcesDirectory)
+    displayName: Run InvokeBuild script
 
   - ${{ parameters.preBuild }}
 

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -71,7 +71,7 @@ jobs:
                               -Force
       }
       if (!(Get-Module -ListAvailable InvokeBuild)) {
-        Install-Module InvokeBuild -Repository PSGalley -Force
+        Install-Module InvokeBuild -Repository PSGallery -Force
       }
       Import-Module InvokeBuild
       Invoke-Build "${{ parameters.build_script }}" `

--- a/templates/build.and.release.yml
+++ b/templates/build.and.release.yml
@@ -3,16 +3,6 @@ parameters:
   postCustomEnvironmentVariables: []
   preBuild: []
   postBuild: []
-  preRunExecutableSpecs: []
-  postRunExecutableSpecs: []
-  preSpecsReport: []
-  postSpecsReport: []
-  prePublishCodeCoverageReport: []
-  postPublishCodeCoverageReport: []
-  postSpecs: []
-  preCreateNuGetPackages: []
-  postCreateNuGetPackages: []
-  postPack: []
   preCopyNugetPackages: []
   postCopyNugetPackages: []
   prePublishReleaseArtifacts: []
@@ -24,7 +14,8 @@ parameters:
   vmImage: ''
   service_connection_nuget_org: '' 
   service_connection_github: '' 
-  solution_to_build: ''
+  build_script: ''
+  build_task: '.'
   netSdkVersion: '3.x'
 
 jobs:
@@ -36,7 +27,6 @@ jobs:
     BuildConfiguration: 'Release'
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    SolutionToBuild: ${{ parameters.solution_to_build }}
 
     # We have dependencies on the following Environment Variables:
     # GITVERSION_PRERELEASETAG
@@ -50,7 +40,6 @@ jobs:
   - template: install.dotnet-global-tools.workaround.yml
     parameters:
       netSdkVersion: ${{ parameters.netSdkVersion }}
-  - template: install-and-run-gitversion.yml
 
   - ${{ parameters.preCustomEnvironmentVariables }}
 
@@ -73,85 +62,23 @@ jobs:
 
   - ${{ parameters.preBuild }}
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Restore & Build'
-    inputs:
-      command: 'build'
-      projects: $(SolutionToBuild)
-      arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer)'
-      versioningScheme: byBuildNumber
-      buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
+  # Executes the 'InvokeBuild' build script
+  - pwsh: |
+      if (!(Get-Module -ListAvailable InvokeBuild)) {
+        Install-Module InvokeBuild -Repository PSGalley -Force
+      }
+      Import-Module InvokeBuild
+      Invoke-Build "${{ parameters.build_script }}" `
+                   -Task "${{ parameters.build_task }}" `
+                   -Configuration "$(BuildConfiguration)" `
+                   -BuildRepositoryUri "$(Build.Repository.Uri)" `
+                   -SourcesDir "$(Build.SourcesDirectory)" `
+                   -CoverageDir "$(Build.SourcesDirectory)/CodeCoverage" `
+                   -TestReportTypes "HtmlInline_AzurePipelines;Cobertura" `
+                   -PackagesDir "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)"
+    workingDirectory: $(Build.SourcesDirectory)
 
-  - ${{ parameters.postBuild }}
-  
-  - ${{ parameters.preRunExecutableSpecs }}
-
-  # The 'test' command was not honouring the 'nobuild' setting, so now we pass is via the
-  # 'arguments' parameter which it does support. 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Executable Specifications'
-    inputs:
-      command: 'test'
-      projects: $(SolutionToBuild)
-      arguments: '-c $(BuildConfiguration) --no-build --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
-  
-  - ${{ parameters.postRunExecutableSpecs }}
-
-  - ${{ parameters.preSpecsReport }}
-
-  - script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool
-      reportgenerator "-reports:$(Build.SourcesDirectory)/**/**/coverage.cobertura.xml" "-targetdir:$(Build.SourcesDirectory)/CodeCoverage" "-reporttypes:HtmlInline_AzurePipelines;Cobertura"
-    displayName: 'Generate Code Coverage Report'
-
-  - ${{ parameters.postSpecsReport }}
-
-  - ${{ parameters.prePublishCodeCoverageReport }}
-
-  - task: PublishCodeCoverageResults@1
-    displayName: 'Publish Code Coverage Report'
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
-      reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
-
-  - ${{ parameters.postPublishCodeCoverageReport }}
-
-  - ${{ parameters.postSpecs }}
-
-  - ${{ parameters.preCreateNuGetPackages }}
-
-  # We switched to using the 'custom' variant as the 'pack' command was not honoring the 'nobuild' setting, and 
-  # it also does not support the 'arguments' parameter. However, using 'custom' means we have to build the
-  # command-line ourselves.
-  - task: DotNetCoreCLI@2
-    displayName: 'Create NuGet Packages'
-    inputs:
-      command: custom
-      custom: pack
-      projects: $(SolutionToBuild)
-      arguments: >
-        -c $(BuildConfiguration)
-        --no-build
-        --no-restore
-        --output $(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)
-        /p:EndjinRepositoryUrl="$(Build.Repository.Uri)"
-        /p:PackageVersion=$(GitVersion.SemVer)
-        --verbosity Detailed
-
-  - ${{ parameters.postCreateNuGetPackages }}
-  
-  - task: DotNetCoreCLI@2
-    displayName: 'Install nupkgversion global tool'
-    inputs:
-      command: custom
-      custom: tool
-      arguments: install -g nupkgversion
-
-  - script: 'nupkgversion "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)" https://api.nuget.org/v3/index.json'
-    displayName: 'Run nupkgversion'
-
-  - ${{ parameters.postPack }}
+  - ${{ parameters.preBuild }}
 
   - ${{ parameters.preCopyNugetPackages }}
 

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -1,6 +1,9 @@
 parameters:
-  gitversion_semver: ''
-  gitversion_prerelease_tag: ''
+- name: gitversion_semver
+  type: string
+- name: gitversion_isprerelease
+  type: boolean
+  
   endjin_repository_name: ''
   preCopyNugetPackages: []
   postCopyNugetPackages: []
@@ -20,16 +23,11 @@ steps:
 
 # Determine required pre-release/publish behaviour
 - powershell: |
-    Write-Host ("GitVersion Variables:`n{0}" -f (gci env:\GITVERSION* | ft | Out-String))
-
-    $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))
-    Write-Host "Endjin_IsPreRelease: '$isPreRelease'"
-    Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"
-
-    $publishFlag = $env:Endjin.ForcePublish -or !($isPreRelease)
-    Write-Host "Endjin_PublishFlag: '$publishFlag'"
-    Write-Host "##vso[task.setvariable variable=Endjin_PublishFlag]$publishFlag"
-  displayName: 'Set Environment Variables'
+    Write-Host "gitversion_semver:       '${{ parameters.gitversion_semver }}'"
+    Write-Host "gitversion_isprerelease: '${{ parameters.gitversion_isprerelease }}'"
+    Write-Host "endjin_repository_name:  '${{ parameters.endjin_repository_name }}'"
+  condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
+  displayName: 'Debug parameter values'
 
 - ${{ parameters.preCopyNugetPackages }}
 
@@ -58,20 +56,15 @@ steps:
 
 - ${{ parameters.preCreateGitHubRelease }}
 
-- powershell: |
-    Write-Host "Endjin_IsPreRelease: '$(Endjin_IsPreRelease)'"
-    Write-Host "Endjin_PublishFlag: '$(Endjin_PublishFlag)'"
-  displayName: 'Output Environment Variables'
-
 - task: GithubRelease@0 
   displayName: 'Create GitHub Release'      
-  condition: and(succeeded(), variables['Endjin_PublishFlag'])
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])))
   inputs:
     gitHubConnection: ${{ parameters.service_connection_github }}
     repositoryName: ${{ parameters.endjin_repository_name }}
     tagSource: manual
     tag: ${{ parameters.gitversion_semver }}
-    isPreRelease: $(Endjin_IsPreRelease)
+    isPreRelease: ${{ parameters.gitversion_isprerelease }}
     assets: |
         $(Build.ArtifactStagingDirectory)/Release/**
 
@@ -81,7 +74,7 @@ steps:
 
 - task: NuGetCommand@2
   displayName: 'Publish to nuget.org'
-  condition: and(succeeded(), variables['Endjin_PublishFlag'])
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])))
   inputs:
     command: push
     nuGetFeedType: external
@@ -122,7 +115,7 @@ steps:
                       -Method Post `
                       -body (ConvertTo-Json $body -Depth 99) `
                       -ContentType 'application/json'
-  condition: and(succeeded(), variables['Endjin_PublishFlag'], ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
   displayName: Send notification to Slack channel
   env:
     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -1,0 +1,124 @@
+parameters:
+  gitversion_semver: ''
+  gitversion_prerelease_tag: ''
+  endjin_repository_name: ''
+  preCopyNugetPackages: []
+  postCopyNugetPackages: []
+  prePublishReleaseArtifacts: []
+  postPublishReleaseArtifacts: []
+  preCreateGitHubRelease: []
+  postCreateGitHubRelease: []
+  prePublishNugetPackages: []
+  postPublishNugetPackages: []
+  service_connection_github: ''
+  service_connection_nuget_org: ''
+
+  # We have dependencies on the following Build Variables:
+  # Endjin.ForcePublish
+  # Endjin_Slack_ReleasesWebhookUri
+steps:
+
+# Determine required pre-release/publish behaviour
+- powershell: |
+    Write-Host ("ENVIRONMENT VARIABLES DEBUG:`n{0}" -f (gci env:\GITVERSION*))
+
+    $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG)
+    Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"
+
+    $publishFlag = $env:Endjin.ForcePublish -or !($isPreRelease)
+    Write-Host "##vso[task.setvariable variable=Endjin_PublishFlag]$publishFlag"
+  displayName: 'Set Environment Variables'
+
+- ${{ parameters.preCopyNugetPackages }}
+
+- task: CopyFiles@2
+  displayName: 'Copy Nuget Packages To Release Folder'
+  inputs:
+    SourceFolder: '$(Build.ArtifactStagingDirectory)'
+    Contents: |
+      Packages/**/*.nupkg
+      Packages/**/*.snupkg
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/Release/NuGet'
+
+- ${{ parameters.postCopyNugetPackages }}
+- ${{ parameters.prePublishReleaseArtifacts }}
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Release Artifacts'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Release'
+
+- ${{ parameters.postPublishReleaseArtifacts }}
+
+- task: NuGetToolInstaller@0
+  inputs:
+    versionSpec: '5.1.0'
+
+- ${{ parameters.preCreateGitHubRelease }}
+
+- task: GithubRelease@0 
+  displayName: 'Create GitHub Release'      
+  condition: and(succeeded(), variables['Endjin_PublishFlag'])
+  inputs:
+    gitHubConnection: ${{ parameters.service_connection_github }}
+    repositoryName: ${{ parameters.endjin_repository_name }}
+    tagSource: manual
+    tag: ${{ parameters.gitversion_semver }}
+    isPreRelease: $(Endjin_IsPreRelease)
+    assets: |
+        $(Build.ArtifactStagingDirectory)/Release/**
+
+- ${{ parameters.postCreateGitHubRelease }}
+
+- ${{ parameters.prePublishNugetPackages }}
+
+- task: NuGetCommand@2
+  displayName: 'Publish to nuget.org'
+  condition: and(succeeded(), variables['Endjin_PublishFlag'])
+  inputs:
+    command: push
+    nuGetFeedType: external
+    publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+    versioningScheme: byBuildNumber
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
+
+- ${{ parameters.postPublishNugetPackages }}
+
+- pwsh: |
+    $body = @{
+      username = "endjin-bot"
+      icon_emoji = ":mike:"
+    }
+
+    Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+    $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/Packages"
+    Write-Host $packages
+
+    $blocks = @()
+    $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+    $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+
+    $packagesText = ""
+
+    foreach ($p in $packages) {
+        $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+        $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+    }
+
+    $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+    $blocks += @{ type = "divider" }
+    $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+
+    $body += @{ blocks = $blocks }
+    Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+    Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+                      -Method Post `
+                      -body (ConvertTo-Json $body -Depth 99) `
+                      -ContentType 'application/json'
+  condition: and(succeeded(), variables['Endjin_PublishFlag']), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  displayName: Send notification to Slack channel
+  env:
+    Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+    Endjin_Repository_Name: ${{ parameters.endjin_repository_name }}
+    GitVersion_SemVer: ${{ parameters.gitversion_semver }}
+    Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -20,7 +20,7 @@ steps:
 
 # Determine required pre-release/publish behaviour
 - powershell: |
-    Write-Host ("ENVIRONMENT VARIABLES DEBUG:`n{0}" -f ((gci env:\GITVERSION*).Name|Out-String))
+    Write-Host ("GitVersion Variables:`n{0}" -f (gci env:\GITVERSION* | ft | Out-String))
 
     $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))
     Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -115,7 +115,7 @@ steps:
                       -Method Post `
                       -body (ConvertTo-Json $body -Depth 99) `
                       -ContentType 'application/json'
-  condition: and(succeeded(), variables['Endjin_PublishFlag']), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  condition: and(succeeded(), variables['Endjin_PublishFlag'], ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
   displayName: Send notification to Slack channel
   env:
     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -1,10 +1,9 @@
 parameters:
-- name: gitversion_semver
-  type: string
-- name: gitversion_isprerelease
-  type: boolean
-  
-  endjin_repository_name: ''
+  gitversion_semver:
+  gitversion_isprerelease:
+  endjin_repository_name:
+  service_connection_github:
+  service_connection_nuget_org:
   preCopyNugetPackages: []
   postCopyNugetPackages: []
   prePublishReleaseArtifacts: []
@@ -13,8 +12,6 @@ parameters:
   postCreateGitHubRelease: []
   prePublishNugetPackages: []
   postPublishNugetPackages: []
-  service_connection_github: ''
-  service_connection_nuget_org: ''
 
   # We have dependencies on the following Build Variables:
   # Endjin.ForcePublish

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -13,12 +13,15 @@ parameters:
   prePublishNugetPackages: []
   postPublishNugetPackages: []
 
-variables:
-  Endjin_IsPreRelease: ${{ parameters.gitversion_isprerelease }}      # parameters seem not to be accessible in condition expressions
   # We have dependencies on the following Build Variables:
   # Endjin.ForcePublish
   # Endjin_Slack_ReleasesWebhookUri
 steps:
+
+# parameters seem not to be accessible in condition expressions, so we need this as a variable
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]${{ parameters.gitversion_isprerelease }}"
+  displayName: 'Set Endjin_IsPreRelease variable'
 
 # Determine required pre-release/publish behaviour
 - powershell: |

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -13,6 +13,8 @@ parameters:
   prePublishNugetPackages: []
   postPublishNugetPackages: []
 
+variables:
+  Endjin_IsPreRelease: ${{ parameters.gitversion_isprerelease }}      # parameters seem not to be accessible in condition expressions
   # We have dependencies on the following Build Variables:
   # Endjin.ForcePublish
   # Endjin_Slack_ReleasesWebhookUri
@@ -23,6 +25,7 @@ steps:
     Write-Host "gitversion_semver:       '${{ parameters.gitversion_semver }}'"
     Write-Host "gitversion_isprerelease: '${{ parameters.gitversion_isprerelease }}'"
     Write-Host "endjin_repository_name:  '${{ parameters.endjin_repository_name }}'"
+    Write-Host "Endjin_IsPreRelease:     '$(Endjin_IsPreRelease)'"
   condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
   displayName: 'Debug parameter values'
 
@@ -55,13 +58,13 @@ steps:
 
 - task: GithubRelease@0 
   displayName: 'Create GitHub Release'      
-  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])))
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(variables['Endjin_IsPreRelease'])))
   inputs:
     gitHubConnection: ${{ parameters.service_connection_github }}
     repositoryName: ${{ parameters.endjin_repository_name }}
     tagSource: manual
     tag: ${{ parameters.gitversion_semver }}
-    isPreRelease: ${{ parameters.gitversion_isprerelease }}
+    isPreRelease: $(Endjin_IsPreRelease)
     assets: |
         $(Build.ArtifactStagingDirectory)/Release/**
 
@@ -71,7 +74,7 @@ steps:
 
 - task: NuGetCommand@2
   displayName: 'Publish to nuget.org'
-  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])))
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(variables['Endjin_IsPreRelease'])))
   inputs:
     command: push
     nuGetFeedType: external
@@ -112,7 +115,7 @@ steps:
                       -Method Post `
                       -body (ConvertTo-Json $body -Depth 99) `
                       -ContentType 'application/json'
-  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(parameters['gitversion_isprerelease'])), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  condition: and(succeeded(), or(variables['Endjin.ForcePublish'], not(variables['Endjin_IsPreRelease'])), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
   displayName: Send notification to Slack channel
   env:
     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -23,9 +23,11 @@ steps:
     Write-Host ("GitVersion Variables:`n{0}" -f (gci env:\GITVERSION* | ft | Out-String))
 
     $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))
+    Write-Host "Endjin_IsPreRelease: '$isPreRelease'"
     Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"
 
     $publishFlag = $env:Endjin.ForcePublish -or !($isPreRelease)
+    Write-Host "Endjin_PublishFlag: '$publishFlag'"
     Write-Host "##vso[task.setvariable variable=Endjin_PublishFlag]$publishFlag"
   displayName: 'Set Environment Variables'
 

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -20,7 +20,7 @@ steps:
 
 # Determine required pre-release/publish behaviour
 - powershell: |
-    Write-Host ("ENVIRONMENT VARIABLES DEBUG:`n{0}" -f (gci env:\GITVERSION*))
+    Write-Host ("ENVIRONMENT VARIABLES DEBUG:`n{0}" -f ((gci env:\GITVERSION*).Name|Out-String))
 
     $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))
     Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -58,6 +58,11 @@ steps:
 
 - ${{ parameters.preCreateGitHubRelease }}
 
+- powershell: |
+    Write-Host "Endjin_IsPreRelease: '$($env:Endjin_IsPreRelease)'"
+    Write-Host "Endjin_PublishFlag: '$($env:Endjin_PublishFlag)'"
+  displayName: 'Output Environment Variables'
+
 - task: GithubRelease@0 
   displayName: 'Create GitHub Release'      
   condition: and(succeeded(), variables['Endjin_PublishFlag'])

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -59,8 +59,8 @@ steps:
 - ${{ parameters.preCreateGitHubRelease }}
 
 - powershell: |
-    Write-Host "Endjin_IsPreRelease: '$($env:Endjin_IsPreRelease)'"
-    Write-Host "Endjin_PublishFlag: '$($env:Endjin_PublishFlag)'"
+    Write-Host "Endjin_IsPreRelease: '$(Endjin_IsPreRelease)'"
+    Write-Host "Endjin_PublishFlag: '$(Endjin_PublishFlag)'"
   displayName: 'Output Environment Variables'
 
 - task: GithubRelease@0 

--- a/templates/stage.and.publish.packages.yml
+++ b/templates/stage.and.publish.packages.yml
@@ -22,7 +22,7 @@ steps:
 - powershell: |
     Write-Host ("ENVIRONMENT VARIABLES DEBUG:`n{0}" -f (gci env:\GITVERSION*))
 
-    $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG)
+    $isPreRelease = -not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))
     Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$isPreRelease"
 
     $publishFlag = $env:Endjin.ForcePublish -or !($isPreRelease)


### PR DESCRIPTION
Prompted by the build issues we were seeing with Vellum, whereby local builds worked but the pipeline did not, this uses the [InvokeBuild](https://github.com/nightroman/Invoke-Build) PowerShell module to perform many of the actions currently handled via ADO tasks in the `build.and.release` template into a build script that can be executed locally.

Similar extension points are provided for adding functionality to the core process.  This initial consumer of this is the [vellum-cli](https://github.com/vellum-dotnet/vellum-cli/tree/feature/invokebuild-spike) project.