### PR TITLE
Update to latest GitVersion.Tool

### DIFF
--- a/templates/install-and-run-gitversion.yml
+++ b/templates/install-and-run-gitversion.yml
@@ -5,19 +5,8 @@ steps:
   inputs:
     command: custom
     custom: 'tool'
-    arguments: 'install -g GitVersion.Tool --version 5.2.0'
+    arguments: 'install -g GitVersion.Tool --version 5.6.6'
 
 - script: 'dotnet-gitversion /output buildserver /nofetch'
   name: 'RunGitVersion'
   displayName: 'Run GitVersion'
-
-# Starting with GitVersion 5.2.0, GitVersion includes isOutput=true on all of the variables it
-# sets, which is a breaking change. It means that these variables are no longer available with
-# the same name - they must now be qualified by the name of the task that produced them.
-# You can't turn this off, so we have to adapt to it. This just republishes them by their
-# old names, meaning anything previously depending on those names will continue to work.
-- powershell: |
-    Write-Host "##vso[task.setvariable variable=GitVersion.SemVer]$(RunGitVersion.GitVersion.SemVer)"
-    Write-Host "##vso[task.setvariable variable=GitVersion.PreReleaseTag]$(RunGitVersion.GitVersion.PreReleaseTag)"
-    Write-Host "##vso[task.setvariable variable=GitVersion.MajorMinorPatch]$(RunGitVersion.GitVersion.MajorMinorPatch)"
-  displayName: 'Publish GitVersion variables'


### PR DESCRIPTION
Also removes workaround for variables being published with the wrong name, as this has now been fixed.

Addresses #45.