### PR TITLE
Add templates for scripted build

### DIFF
--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -51,11 +51,20 @@ jobs:
   #   parameters:
   #     netSdkVersion: ${{ parameters.netSdkVersion }}
   - task: UseDotNet@2
-    displayName: 'Install .NET Core SDK ${{ parameters.netSdkVersion }}'
+    displayName: 'Install .NET SDK ${{ parameters.netSdkVersion }}'
     inputs:
       packageType: sdk
       version: ${{ parameters.netSdkVersion }}
       installationPath: $(Agent.ToolsDirectory)/dotnet
+
+  # At some point presumably a version of GitVersion will come out that doesn't
+  # need this. Once Endjin.RecommendedPractices.Build upgrades to a suitable
+  # version we can move to that.
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core 3.1 runtime (required by GitVersion)'
+    inputs:
+      packageType: runtime
+      version: 3.1
 
   # - template: install-and-run-gitversion.yml
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -34,6 +34,10 @@ jobs:
 
   variables:
     BuildConfiguration: 'Release'
+    ${{ if or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment']) }}
+      BuildScriptLogLevel: 'detailed'
+    ${{ else }}
+      BuildScriptLogLevel: 'minimal'
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
@@ -75,6 +79,7 @@ jobs:
     inputs:
       targetType: 'filePath'
       filePath: "$(Build.SourcesDirectory)/build.ps1"
+      arguments: -Configuration $(BuildConfiguration) -BuildRepositoryUri $(Build.Repository.Uri) -SourcesDir $(Build.SourcesDirectory) -CoverageDir $(Build.SourcesDirectory)/CodeCoverage -LogLevel $(BuildScriptLogLevel)
       pwsh: true
     displayName: 'Run build.ps1'
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -205,8 +205,12 @@ jobs:
   - ${{ parameters.preCreateGitHubRelease }}
 
   - task: GithubRelease@0 
-    displayName: 'Create GitHub Release'      
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    displayName: 'Create GitHub Release'
+    # Due to this bug:
+    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+    # GitVersion variables currently don't have the GitVersion. prefix.
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')))
+    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
     inputs:
       gitHubConnection: ${{ parameters.service_connection_github }}
       repositoryName: $(Endjin_Repository_Name)

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -34,9 +34,9 @@ jobs:
 
   variables:
     BuildConfiguration: 'Release'
-    ${{ if or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment']) }}
+    ${{ if or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment']) }}:
       BuildScriptLogLevel: 'detailed'
-    ${{ else }}
+    ${{ else }}:
       BuildScriptLogLevel: 'minimal'
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -93,7 +93,7 @@ jobs:
   - powershell: |
       Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$(-not ([string]::IsNullOrEmpty($Env:SemVer)))"
       Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$Env:PreReleaseTag"
-      Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$Env:SemVer)"
+      Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$Env:SemVer"
     displayName: 'Set Version Information Build Variables'
     env:
       PreReleaseTag: $(PreReleaseTag)

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -64,7 +64,7 @@ jobs:
     displayName: 'Install .NET Core 3.1 runtime (required by GitVersion)'
     inputs:
       packageType: runtime
-      version: 3.1
+      version: 3.1.x
 
   # - template: install-and-run-gitversion.yml
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -91,10 +91,13 @@ jobs:
   # elsewhere in the script, so that if the scripted build is updated to reinstate the GITVERSION_
   # prefix for these build variables, we only have to change them in one place.
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($PreReleaseTag))))"
-      Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$($PreReleaseTag))"
-      Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$($SemVer))"
+      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$(-not ([string]::IsNullOrEmpty($Env:SemVer)))"
+      Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$Env:PreReleaseTag"
+      Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$Env:SemVer)"
     displayName: 'Set Version Information Build Variables'
+    env:
+      PreReleaseTag: $(PreReleaseTag)
+      SemVer: $(SemVer)
 
   # Scripted build (V0.1.0) currently doesn't do this for us.
   - powershell: |

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -57,14 +57,14 @@ jobs:
       version: ${{ parameters.netSdkVersion }}
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  # At some point presumably a version of GitVersion will come out that doesn't
-  # need this. Once Endjin.RecommendedPractices.Build upgrades to a suitable
-  # version we can move to that.
-  - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.1 runtime (required by GitVersion)'
-    inputs:
-      packageType: runtime
-      version: 3.1.x
+  # # At some point presumably a version of GitVersion will come out that doesn't
+  # # need this. Once Endjin.RecommendedPractices.Build upgrades to a suitable
+  # # version we can move to that.
+  # - task: UseDotNet@2
+  #   displayName: 'Install .NET Core 3.1 runtime (required by GitVersion)'
+  #   inputs:
+  #     packageType: runtime
+  #     version: 3.1.x
 
   # - template: install-and-run-gitversion.yml
 
@@ -215,7 +215,11 @@ jobs:
       gitHubConnection: ${{ parameters.service_connection_github }}
       repositoryName: $(Endjin_Repository_Name)
       tagSource: manual
-      tag: $(GitVersion.SemVer) 
+      # Due to this bug:
+      # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+      # GitVersion variables currently don't have the GitVersion. prefix.
+      #tag: $(GitVersion.SemVer)
+      tag: $(SemVer)
       isPreRelease: $(Endjin_IsPreRelease)
       assets: |
           $(Build.ArtifactStagingDirectory)/Release/**
@@ -271,11 +275,19 @@ jobs:
                         -Method Post `
                         -body (ConvertTo-Json $body -Depth 99) `
                         -ContentType 'application/json'
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    # Due to this bug:
+    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+    # GitVersion variables currently don't have the GitVersion. prefix.
+    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
     displayName: Send notification to Slack channel
     env:
       Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
       Endjin_Repository_Name: $(Endjin_Repository_Name)
-      GitVersion_SemVer: $(GitVersion.SemVer)
+      # Due to this bug:
+      # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+      # GitVersion variables currently don't have the GitVersion. prefix.
+      #GitVersion_SemVer: $(GitVersion.SemVer)
+      GitVersion_SemVer: $(SemVer)
       Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -98,8 +98,10 @@ jobs:
 
   # Scripted build (V0.1.0) currently doesn't do this for us.
   - powershell: |
-      Write-Host "##vso[build.updatebuildnumber]$($Endjin_SemVer)"
+      Write-Host "##vso[build.updatebuildnumber]$($Env:GitVersion_SemVer)"
     displayName: 'Set Build Number'
+    env:
+      GitVersion_SemVer: $(Endjin_SemVer)
 
   - ${{ parameters.prePublishCodeCoverageReport }}
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -79,8 +79,10 @@ jobs:
     displayName: 'Print Environment Variables'
 
   - task: PowerShell@2
-    filePath: "$(Build.SourcesDirectory)/build.ps1"
-    pwsh: true
+    inputs:
+      targetType: 'filePath'
+      filePath: "$(Build.SourcesDirectory)/build.ps1"
+      pwsh: true
     displayName: 'Run build.ps1'
 
   # - ${{ parameters.preBuild }}

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -226,7 +226,11 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Publish to nuget.org'
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    # Due to this bug:
+    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+    # GitVersion variables currently don't have the GitVersion. prefix.
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')))
+    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
     inputs:
       command: push
       nuGetFeedType: external

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -1,0 +1,261 @@
+parameters:
+  preCustomEnvironmentVariables: []
+  postCustomEnvironmentVariables: []
+  # preBuild: []
+  # postBuild: []
+  # preRunExecutableSpecs: []
+  # postRunExecutableSpecs: []
+  # preSpecsReport: []
+  # postSpecsReport: []
+  prePublishCodeCoverageReport: []
+  postPublishCodeCoverageReport: []
+  # postSpecs: []
+  # preCreateNuGetPackages: []
+  # postCreateNuGetPackages: []
+  # postPack: []
+  preCopyNugetPackages: []
+  postCopyNugetPackages: []
+  prePublishReleaseArtifacts: []
+  postPublishReleaseArtifacts: []
+  preCreateGitHubRelease: []
+  postCreateGitHubRelease: []
+  prePublishNugetPackages: []
+  postPublishNugetPackages: []
+  vmImage: ''
+  service_connection_nuget_org: '' 
+  service_connection_github: '' 
+  solution_to_build: ''
+  netSdkVersion: '6.x'
+
+jobs:
+- job: Build
+  pool:
+    vmImage: ${{ parameters.vmImage }}
+
+  variables:
+    BuildConfiguration: 'Release'
+    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+    SolutionToBuild: ${{ parameters.solution_to_build }}
+
+    # We have dependencies on the following Environment Variables:
+    # GITVERSION_PRERELEASETAG
+    # BUILD_REPOSITORY_NAME
+
+    # We have dependencies on the following Build Variables:
+    # Endjin_Service_Connection_NuGet_Org
+    # Endjin_Service_Connection_GitHub
+    # Endjin.ForcePublish
+  steps:
+  # - template: install.dotnet-global-tools.workaround.yml
+  #   parameters:
+  #     netSdkVersion: ${{ parameters.netSdkVersion }}
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK ${{ parameters.netSdkVersion }}'
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.netSdkVersion }}
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
+  # - template: install-and-run-gitversion.yml
+
+  - ${{ parameters.preCustomEnvironmentVariables }}
+
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))))"
+      Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
+    displayName: 'Set Environment Variables'
+
+  - powershell: |
+      Write-Host "Initializing $(Build.ArtifactStagingDirectory)/Release"
+      New-Item -Path $(Build.ArtifactStagingDirectory) -Name "Release" -ItemType "directory"
+    displayName: 'Initialize Artifact Staging Release Directory'
+
+  - ${{ parameters.postCustomEnvironmentVariables }}
+
+  # Useful for debugging purposes
+  - powershell: 'gci Env:'
+    condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
+    displayName: 'Print Environment Variables'
+
+  - powershell:
+    filePath: "$(Build.SourcesDirectory)/build.ps1"
+    displayName: 'Run build.ps1'
+
+  # - ${{ parameters.preBuild }}
+
+  # - task: DotNetCoreCLI@2
+  #   displayName: 'Restore & Build'
+  #   inputs:
+  #     command: 'build'
+  #     projects: $(SolutionToBuild)
+  #     arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer)'
+  #     versioningScheme: byBuildNumber
+  #     buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
+
+  # - ${{ parameters.postBuild }}
+  
+  # - ${{ parameters.preRunExecutableSpecs }}
+
+  # # The 'test' command was not honouring the 'nobuild' setting, so now we pass is via the
+  # # 'arguments' parameter which it does support. 
+  # - task: DotNetCoreCLI@2
+  #   displayName: 'Run Executable Specifications'
+  #   inputs:
+  #     command: 'test'
+  #     projects: $(SolutionToBuild)
+  #     arguments: '-c $(BuildConfiguration) --no-build --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
+  
+  # - ${{ parameters.postRunExecutableSpecs }}
+
+  # - ${{ parameters.preSpecsReport }}
+
+  # - script: |
+  #     dotnet tool install -g dotnet-reportgenerator-globaltool
+  #     reportgenerator "-reports:$(Build.SourcesDirectory)/**/**/coverage.cobertura.xml" "-targetdir:$(Build.SourcesDirectory)/CodeCoverage" "-reporttypes:HtmlInline_AzurePipelines;Cobertura"
+  #   displayName: 'Generate Code Coverage Report'
+
+  # - ${{ parameters.postSpecsReport }}
+
+  - ${{ parameters.prePublishCodeCoverageReport }}
+
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Publish Code Coverage Report'
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
+      reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
+
+  - ${{ parameters.postPublishCodeCoverageReport }}
+
+  # - ${{ parameters.postSpecs }}
+
+  # - ${{ parameters.preCreateNuGetPackages }}
+
+  # # We switched to using the 'custom' variant as the 'pack' command was not honoring the 'nobuild' setting, and 
+  # # it also does not support the 'arguments' parameter. However, using 'custom' means we have to build the
+  # # command-line ourselves.
+  # - task: DotNetCoreCLI@2
+  #   displayName: 'Create NuGet Packages'
+  #   inputs:
+  #     command: custom
+  #     custom: pack
+  #     projects: $(SolutionToBuild)
+  #     arguments: >
+  #       -c $(BuildConfiguration)
+  #       --no-build
+  #       --no-restore
+  #       --output $(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)
+  #       /p:EndjinRepositoryUrl="$(Build.Repository.Uri)"
+  #       /p:PackageVersion=$(GitVersion.SemVer)
+  #       --verbosity Detailed
+
+  # - ${{ parameters.postCreateNuGetPackages }}
+  
+  # - task: DotNetCoreCLI@2
+  #   displayName: 'Install nupkgversion global tool'
+  #   inputs:
+  #     command: custom
+  #     custom: tool
+  #     arguments: install -g nupkgversion
+
+  # - script: 'nupkgversion "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)" https://api.nuget.org/v3/index.json'
+  #   displayName: 'Run nupkgversion'
+
+  # - ${{ parameters.postPack }}
+
+  - ${{ parameters.preCopyNugetPackages }}
+
+  - task: CopyFiles@2
+    displayName: 'Copy Nuget Packages To Release Folder'
+    inputs:
+      #SourceFolder: '$(Build.ArtifactStagingDirectory)'
+      SourceFolder: '$(Build.SourcesDirectory)'
+      Contents: |
+        _packages/**/*.nupkg
+        _packages/**/*.snupkg
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/Release/NuGet'
+
+  - ${{ parameters.postCopyNugetPackages }}
+  - ${{ parameters.prePublishReleaseArtifacts }}
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Release Artifacts'
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/Release'
+
+  - ${{ parameters.postPublishReleaseArtifacts }}
+
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: '5.1.0'
+  
+  - ${{ parameters.preCreateGitHubRelease }}
+
+  - task: GithubRelease@0 
+    displayName: 'Create GitHub Release'      
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    inputs:
+      gitHubConnection: ${{ parameters.service_connection_github }}
+      repositoryName: $(Endjin_Repository_Name)
+      tagSource: manual
+      tag: $(GitVersion.SemVer) 
+      isPreRelease: $(Endjin_IsPreRelease)
+      assets: |
+          $(Build.ArtifactStagingDirectory)/Release/**
+
+  - ${{ parameters.postCreateGitHubRelease }}
+
+  - ${{ parameters.prePublishNugetPackages }}
+
+  - task: NuGetCommand@2
+    displayName: 'Publish to nuget.org'
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    inputs:
+      command: push
+      nuGetFeedType: external
+      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+      versioningScheme: byBuildNumber
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
+
+  - ${{ parameters.postPublishNugetPackages }}
+
+  - pwsh: |
+      $body = @{
+        username = "endjin-bot"
+        icon_emoji = ":mike:"
+      }
+
+      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/Packages"
+      Write-Host $packages
+
+      $blocks = @()
+      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+
+      $packagesText = ""
+
+      foreach ($p in $packages) {
+          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+      }
+
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+      $blocks += @{ type = "divider" }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+
+      $body += @{ blocks = $blocks }
+      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+                        -Method Post `
+                        -body (ConvertTo-Json $body -Depth 99) `
+                        -ContentType 'application/json'
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    displayName: Send notification to Slack channel
+    env:
+      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+      Endjin_Repository_Name: $(Endjin_Repository_Name)
+      GitVersion_SemVer: $(GitVersion.SemVer)
+      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+      

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -1,18 +1,19 @@
+# This template is designed for builds using the Endjin.RecommendedPractices.Build module:
+#   https://www.powershellgallery.com/packages/Endjin.RecommendedPractices.Build
+#   https://github.com/endjin/Endjin.RecommendedPractices.Build
+# The majority of the build process is executed by a `build.ps1` script in the root of the
+# project.
+#
+# With scripted builds, many of the extensibility points exposed by `build.and.release.yml`
+# (e.g. `preBuild`, `postBuild`, `preRunExecutableSpecs`, etc.) are now supplied by the
+# build script, and not this Azure DevOps template.
+# However, there are still some extensibility points specific to the Azure DevOps pipeline
+# execution.
 parameters:
   preCustomEnvironmentVariables: []
   postCustomEnvironmentVariables: []
-  # preBuild: []
-  # postBuild: []
-  # preRunExecutableSpecs: []
-  # postRunExecutableSpecs: []
-  # preSpecsReport: []
-  # postSpecsReport: []
   prePublishCodeCoverageReport: []
   postPublishCodeCoverageReport: []
-  # postSpecs: []
-  # preCreateNuGetPackages: []
-  # postCreateNuGetPackages: []
-  # postPack: []
   preCopyNugetPackages: []
   postCopyNugetPackages: []
   prePublishReleaseArtifacts: []
@@ -22,9 +23,8 @@ parameters:
   prePublishNugetPackages: []
   postPublishNugetPackages: []
   vmImage: ''
-  service_connection_nuget_org: '' 
-  service_connection_github: '' 
-  solution_to_build: ''
+  service_connection_nuget_org: ''
+  service_connection_github: ''
   netSdkVersion: '6.x'
 
 jobs:
@@ -36,20 +36,16 @@ jobs:
     BuildConfiguration: 'Release'
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-    SolutionToBuild: ${{ parameters.solution_to_build }}
 
     # We have dependencies on the following Environment Variables:
-    # GITVERSION_PRERELEASETAG
     # BUILD_REPOSITORY_NAME
 
     # We have dependencies on the following Build Variables:
     # Endjin_Service_Connection_NuGet_Org
     # Endjin_Service_Connection_GitHub
+    # Endjin_Slack_ReleasesWebhookUri
     # Endjin.ForcePublish
   steps:
-  # - template: install.dotnet-global-tools.workaround.yml
-  #   parameters:
-  #     netSdkVersion: ${{ parameters.netSdkVersion }}
   - task: UseDotNet@2
     displayName: 'Install .NET SDK ${{ parameters.netSdkVersion }}'
     inputs:
@@ -57,21 +53,9 @@ jobs:
       version: ${{ parameters.netSdkVersion }}
       installationPath: $(Agent.ToolsDirectory)/dotnet
 
-  # # At some point presumably a version of GitVersion will come out that doesn't
-  # # need this. Once Endjin.RecommendedPractices.Build upgrades to a suitable
-  # # version we can move to that.
-  # - task: UseDotNet@2
-  #   displayName: 'Install .NET Core 3.1 runtime (required by GitVersion)'
-  #   inputs:
-  #     packageType: runtime
-  #     version: 3.1.x
-
-  # - template: install-and-run-gitversion.yml
-
   - ${{ parameters.preCustomEnvironmentVariables }}
 
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($Env:GITVERSION_PRERELEASETAG))))"
       Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
     displayName: 'Set Environment Variables'
 
@@ -94,40 +78,28 @@ jobs:
       pwsh: true
     displayName: 'Run build.ps1'
 
-  # - ${{ parameters.preBuild }}
+  # In non-scripted builds, we run this step much earlier in the process - we can do it immediately
+  # after running GitVersion. But with scripted builds, GitVersion is run by `build.ps` so we can't
+  # use any of its outputs until after the scripted build runs.
+  # Scripted build 0.1.0 sets all the GitVersion outputs into environment variables with a
+  # GITVERSION_ prefix, but currently, due to this bug:
+  #  https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
+  # when it emits them as Build Variables, it does not include the prefix. Environment variable
+  # set by the build script are only available while the build script runs, so it's the build
+  # variables we have to depend on here.
+  # We're giving them an Endjin_ prefix here so we've got a stable name to refer to them by
+  # elsewhere in the script, so that if the scripted build is updated to reinstate the GITVERSION_
+  # prefix for these build variables, we only have to change them in one place.
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($PreReleaseTag))))"
+      Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$($PreReleaseTag))"
+      Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$($SemVer))"
+    displayName: 'Set Version Information Environment Variables'
 
-  # - task: DotNetCoreCLI@2
-  #   displayName: 'Restore & Build'
-  #   inputs:
-  #     command: 'build'
-  #     projects: $(SolutionToBuild)
-  #     arguments: '--configuration $(BuildConfiguration) /p:Version=$(GitVersion.SemVer)'
-  #     versioningScheme: byBuildNumber
-  #     buildProperties: 'EndjinRepositoryUrl="$(Build.Repository.Uri)"'
-
-  # - ${{ parameters.postBuild }}
-  
-  # - ${{ parameters.preRunExecutableSpecs }}
-
-  # # The 'test' command was not honouring the 'nobuild' setting, so now we pass is via the
-  # # 'arguments' parameter which it does support. 
-  # - task: DotNetCoreCLI@2
-  #   displayName: 'Run Executable Specifications'
-  #   inputs:
-  #     command: 'test'
-  #     projects: $(SolutionToBuild)
-  #     arguments: '-c $(BuildConfiguration) --no-build --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
-  
-  # - ${{ parameters.postRunExecutableSpecs }}
-
-  # - ${{ parameters.preSpecsReport }}
-
-  # - script: |
-  #     dotnet tool install -g dotnet-reportgenerator-globaltool
-  #     reportgenerator "-reports:$(Build.SourcesDirectory)/**/**/coverage.cobertura.xml" "-targetdir:$(Build.SourcesDirectory)/CodeCoverage" "-reporttypes:HtmlInline_AzurePipelines;Cobertura"
-  #   displayName: 'Generate Code Coverage Report'
-
-  # - ${{ parameters.postSpecsReport }}
+    # Useful for debugging purposes
+  - powershell: 'gci Env:'
+    condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
+    displayName: 'Print Post-build Environment Variables'
 
   - ${{ parameters.prePublishCodeCoverageReport }}
 
@@ -140,48 +112,11 @@ jobs:
 
   - ${{ parameters.postPublishCodeCoverageReport }}
 
-  # - ${{ parameters.postSpecs }}
-
-  # - ${{ parameters.preCreateNuGetPackages }}
-
-  # # We switched to using the 'custom' variant as the 'pack' command was not honoring the 'nobuild' setting, and 
-  # # it also does not support the 'arguments' parameter. However, using 'custom' means we have to build the
-  # # command-line ourselves.
-  # - task: DotNetCoreCLI@2
-  #   displayName: 'Create NuGet Packages'
-  #   inputs:
-  #     command: custom
-  #     custom: pack
-  #     projects: $(SolutionToBuild)
-  #     arguments: >
-  #       -c $(BuildConfiguration)
-  #       --no-build
-  #       --no-restore
-  #       --output $(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)
-  #       /p:EndjinRepositoryUrl="$(Build.Repository.Uri)"
-  #       /p:PackageVersion=$(GitVersion.SemVer)
-  #       --verbosity Detailed
-
-  # - ${{ parameters.postCreateNuGetPackages }}
-  
-  # - task: DotNetCoreCLI@2
-  #   displayName: 'Install nupkgversion global tool'
-  #   inputs:
-  #     command: custom
-  #     custom: tool
-  #     arguments: install -g nupkgversion
-
-  # - script: 'nupkgversion "$(Build.ArtifactStagingDirectory)/Packages/$(Build.BuildID)" https://api.nuget.org/v3/index.json'
-  #   displayName: 'Run nupkgversion'
-
-  # - ${{ parameters.postPack }}
-
   - ${{ parameters.preCopyNugetPackages }}
 
   - task: CopyFiles@2
     displayName: 'Copy Nuget Packages To Release Folder'
     inputs:
-      #SourceFolder: '$(Build.ArtifactStagingDirectory)'
       SourceFolder: '$(Build.SourcesDirectory)'
       Contents: |
         _packages/**/*.nupkg
@@ -206,20 +141,12 @@ jobs:
 
   - task: GithubRelease@0 
     displayName: 'Create GitHub Release'
-    # Due to this bug:
-    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
-    # GitVersion variables currently don't have the GitVersion. prefix.
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')))
-    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['Endjin_PreReleaseTag'], '')))
     inputs:
       gitHubConnection: ${{ parameters.service_connection_github }}
       repositoryName: $(Endjin_Repository_Name)
       tagSource: manual
-      # Due to this bug:
-      # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
-      # GitVersion variables currently don't have the GitVersion. prefix.
-      #tag: $(GitVersion.SemVer)
-      tag: $(SemVer)
+      tag: $(Endjin_SemVer)
       isPreRelease: $(Endjin_IsPreRelease)
       assets: |
           $(Build.ArtifactStagingDirectory)/Release/**
@@ -230,11 +157,7 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Publish to nuget.org'
-    # Due to this bug:
-    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
-    # GitVersion variables currently don't have the GitVersion. prefix.
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')))
-    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')))
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['Endjin_PreReleaseTag'], '')))
     inputs:
       command: push
       nuGetFeedType: external
@@ -275,19 +198,11 @@ jobs:
                         -Method Post `
                         -body (ConvertTo-Json $body -Depth 99) `
                         -ContentType 'application/json'
-    # Due to this bug:
-    # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
-    # GitVersion variables currently don't have the GitVersion. prefix.
-    #condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['GitVersion.PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    condition: and(succeeded(), or(variables['Endjin.ForcePublish'], eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
     displayName: Send notification to Slack channel
     env:
       Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
       Endjin_Repository_Name: $(Endjin_Repository_Name)
-      # Due to this bug:
-      # https://github.com/endjin/Endjin.RecommendedPractices.Build/issues/3
-      # GitVersion variables currently don't have the GitVersion. prefix.
-      #GitVersion_SemVer: $(GitVersion.SemVer)
-      GitVersion_SemVer: $(SemVer)
+      GitVersion_SemVer: $(Endjin_SemVer)
       Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -78,8 +78,9 @@ jobs:
     condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
     displayName: 'Print Environment Variables'
 
-  - powershell:
+  - task: PowerShell@2
     filePath: "$(Build.SourcesDirectory)/build.ps1"
+    pwsh: true
     displayName: 'Run build.ps1'
 
   # - ${{ parameters.preBuild }}

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -57,14 +57,14 @@ jobs:
 
   - powershell: |
       Write-Host "##vso[task.setvariable variable=Endjin_Repository_Name]$Env:BUILD_REPOSITORY_NAME"
-    displayName: 'Set Environment Variables'
+    displayName: 'Set Build Variables from Environment'
+
+  - ${{ parameters.postCustomEnvironmentVariables }}
 
   - powershell: |
       Write-Host "Initializing $(Build.ArtifactStagingDirectory)/Release"
       New-Item -Path $(Build.ArtifactStagingDirectory) -Name "Release" -ItemType "directory"
     displayName: 'Initialize Artifact Staging Release Directory'
-
-  - ${{ parameters.postCustomEnvironmentVariables }}
 
   # Useful for debugging purposes
   - powershell: 'gci Env:'
@@ -94,12 +94,12 @@ jobs:
       Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$((-not ([string]::IsNullOrEmpty($PreReleaseTag))))"
       Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$($PreReleaseTag))"
       Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$($SemVer))"
-    displayName: 'Set Version Information Environment Variables'
+    displayName: 'Set Version Information Build Variables'
 
-    # Useful for debugging purposes
-  - powershell: 'gci Env:'
-    condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
-    displayName: 'Print Post-build Environment Variables'
+  # Scripted build (V0.1.0) currently doesn't do this for us.
+  - powershell: |
+      Write-Host "##vso[build.updatebuildnumber]$($Endjin_SemVer)"
+    displayName: 'Set Build Number'
 
   - ${{ parameters.prePublishCodeCoverageReport }}
 


### PR DESCRIPTION
This enables the use of https://github.com/endjin/Endjin.RecommendedPractices.Build

This adds `templates/build.and.release.scripted.yml` which enables projects to use that repo's scripted build (which can be a first step towards being able to use GitHub actions instead of Azure DevOps).