### PR TITLE
Include submodules in checkout

### DIFF
--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -50,6 +50,9 @@ jobs:
     # Endjin_Slack_ReleasesWebhookUri
     # Endjin.ForcePublish
   steps:
+  - checkout:
+    submodules: recursive
+
   - task: UseDotNet@2
     displayName: 'Install .NET SDK ${{ parameters.netSdkVersion }}'
     inputs:

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -50,8 +50,7 @@ jobs:
     # Endjin_Slack_ReleasesWebhookUri
     # Endjin.ForcePublish
   steps:
-  - checkout:
-    repository: self
+  - checkout: self
     submodules: recursive
 
   - task: UseDotNet@2

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -51,6 +51,7 @@ jobs:
     # Endjin.ForcePublish
   steps:
   - checkout:
+    repository: self
     submodules: recursive
 
   - task: UseDotNet@2


### PR DESCRIPTION
Azure DevOps does not fetch Git submodules during checkout unless you tell it to. This change tells it to.