### PR TITLE
Update scripted build extensibility points

### DIFF
--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -203,6 +203,11 @@ jobs:
       buildType: 'current'
       artifactName: build
       targetPath: $(Build.SourcesDirectory)
+
+  - ${{ parameters.preCustomEnvironmentVariables }}
+
+  - ${{ parameters.postCustomEnvironmentVariables }}
+
   - task: PowerShell@2
     inputs:
       targetType: 'filePath'
@@ -259,6 +264,11 @@ jobs:
       buildType: 'current'
       artifactName: build
       targetPath: $(Build.SourcesDirectory)
+
+  - ${{ parameters.preCustomEnvironmentVariables }}
+
+  - ${{ parameters.postCustomEnvironmentVariables }}
+        
   - task: PowerShell@2
     inputs:
       targetType: 'filePath'


### PR DESCRIPTION
The `preCustomEnvironmentVariables` and `postCustomEnvironmentVariables` extensibility points are potentially relevant to all 3 phases of the script build (i.e. compile, test, package).

This PR adds them to the latter 2 phases to avoid unexpected build failures when migrating to the scripted build.
