### PR TITLE
Fix GitHub release issue with scripted build template

### DIFF
--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -32,6 +32,7 @@ parameters:
   testTasks: 'Test,TestReport'
   packageTasks: 'Package'
   compileTasksServiceConnection: ''
+  internalVstsFeed: 'endjin-nuget-pre-releases'
 
 jobs:
 - job: Build
@@ -371,11 +372,11 @@ jobs:
 
   - task: NuGetCommand@2
     displayName: 'Publish to internal feed'
-    condition: and(succeeded(), and(ne(variables['Endjin.ForcePublish'], 'true'), ne(variables['Endjin_PreReleaseTag'], '')))
+    condition: and(succeeded(), eq(variables['Endjin.InternalPublish'], 'true'))
     inputs:
       command: push
       nuGetFeedType: internal
-      publishVstsFeed: 'endjin-nuget-pre-releases'
+      publishVstsFeed: ${{ parameters.internalVstsFeed }}
       versioningScheme: Off
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -256,6 +256,9 @@ jobs:
   steps:
   - checkout: self    # ensure we have a git reference to support later tasks
     fetchDepth: 0
+  - pwsh: |
+      ls -la $(Build.SourcesDirectory)
+    displayName: DEBUG - Before artefact download
   - template: install-dotnet-sdks.yml
     parameters:
       netSdkVersion: ${{ parameters.netSdkVersion }}
@@ -266,6 +269,9 @@ jobs:
       buildType: 'current'
       artifactName: build
       targetPath: $(Build.SourcesDirectory)
+  - pwsh: |
+      ls -la $(Build.SourcesDirectory)
+    displayName: DEBUG - After artefact download
 
   - ${{ parameters.preCustomEnvironmentVariables }}
 
@@ -347,7 +353,7 @@ jobs:
     displayName: Debug release condition parameters
     env:
       Endjin_SemVer: $(Endjin_SemVer)
-      Endjin_ForcePublish: $(Endjin.ForcePublish)
+      Endjin_ForcePublish: ${{ variables['Endjin.ForcePublish'] }}
       Endjin_PreReleaseTag: $(Endjin_PreReleaseTag)
       Endjin_IsPreRelease: $(Endjin_IsPreRelease)
 

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -81,6 +81,7 @@ jobs:
       SYSTEM_COLLECTIONURI: $(SYSTEM_COLLECTIONURI)
 
   - checkout: self
+    fetchDepth: 0
     submodules: recursive
 
   - template: install-dotnet-sdks.yml
@@ -254,6 +255,7 @@ jobs:
     PackagesOutputDirName: '_packages'
   steps:
   - checkout: self    # ensure we have a git reference to support later tasks
+    fetchDepth: 0
   - template: install-dotnet-sdks.yml
     parameters:
       netSdkVersion: ${{ parameters.netSdkVersion }}
@@ -298,7 +300,7 @@ jobs:
   # prefix for these build variables, we only have to change them in one place.
   
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$(-not ([string]::IsNullOrEmpty($Env:SemVer)))"
+      Write-Host "##vso[task.setvariable variable=Endjin_IsPreRelease]$(-not ([string]::IsNullOrEmpty($Env:PreReleaseTag)))"
       Write-Host "##vso[task.setvariable variable=Endjin_PreReleaseTag]$Env:PreReleaseTag"
       Write-Host "##vso[task.setvariable variable=Endjin_SemVer]$Env:SemVer"
     displayName: 'Set Version Information Build Variables'
@@ -338,11 +340,13 @@ jobs:
       Write-Host "Endjin_SemVer: '$($env:Endjin_SemVer)'"
       Write-Host "Endjin.ForcePublish: '$($env:Endjin_ForcePublish)'"
       Write-Host "Endjin_PreReleaseTag: '$($env:Endjin_PreReleaseTag)'"
+      Write-Host "Endjin_IsPreRelease: '$($env:Endjin_IsPreRelease)'"
     displayName: Debug release condition parameters
     env:
       Endjin_SemVer: $(Endjin_SemVer)
       Endjin_ForcePublish: $(Endjin.ForcePublish)
       Endjin_PreReleaseTag: $(Endjin_PreReleaseTag)
+      Endjin_IsPreRelease: $(Endjin_IsPreRelease)
 
   - task: GithubRelease@1 
     displayName: 'Create GitHub Release'

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -311,10 +311,13 @@ jobs:
   - ${{ parameters.preCopyNugetPackages }}
 
   - pwsh: |
+      # Ensure we have a 'Release' folder as this needs to exist for the next step
       $nugetDropDir = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "Release" "NuGet"
       if (!(Test-Path $nugetDropDir)) { New-Item -ItemType Directory -Path $nugetDropDir }
-      Copy-Item -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.nupkg -Recurse -Verbose
-      Copy-Item -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.snupkg -Recurse -Verbose
+
+      # Copy any packages that were produced
+      Get-ChildItem -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.nupkg -Recurse | Copy-Item -Destination $nugetDropDir -Verbose
+      Get-ChildItem -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.snupkg -Recurse | Copy-Item -Destination $nugetDropDir -Verbose
     displayName: 'Copy Nuget Packages To Release Folder'
     env:
       PACKAGES_OUTPUT_DIR_NAME: $(PackagesOutputDirName)

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -310,14 +310,14 @@ jobs:
 
   - ${{ parameters.preCopyNugetPackages }}
 
-  - task: CopyFiles@2
+  - pwsh: |
+      $nugetDropDir = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "Release" "NuGet"
+      if (!(Test-Path $nugetDropDir)) { New-Item -ItemType Directory -Path $nugetDropDir }
+      Copy-Item -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.nupkg -Recurse -Verbose
+      Copy-Item -Path $env:PACKAGES_OUTPUT_DIR_NAME -Filter *.snupkg -Recurse -Verbose
     displayName: 'Copy Nuget Packages To Release Folder'
-    inputs:
-      SourceFolder: '$(Build.SourcesDirectory)'
-      Contents: |
-        $(PackagesOutputDirName)/**/*.nupkg
-        $(PackagesOutputDirName)/**/*.snupkg
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/Release/NuGet'
+    env:
+      PACKAGES_OUTPUT_DIR_NAME: $(PackagesOutputDirName)
 
   - ${{ parameters.postCopyNugetPackages }}
   - ${{ parameters.prePublishReleaseArtifacts }}

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -373,55 +373,55 @@ jobs:
 
   - ${{ parameters.prePublishNugetPackages }}
 
-  - task: NuGetCommand@2
-    displayName: 'Publish to nuget.org'
-    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
-    inputs:
-      command: push
-      nuGetFeedType: external
-      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
-      versioningScheme: byBuildNumber
-      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
+  # - task: NuGetCommand@2
+  #   displayName: 'Publish to nuget.org'
+  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
+  #   inputs:
+  #     command: push
+  #     nuGetFeedType: external
+  #     publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+  #     versioningScheme: byBuildNumber
+  #     packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
   - ${{ parameters.postPublishNugetPackages }}
 
-  - pwsh: |
-      $body = @{
-        username = "endjin-bot"
-        icon_emoji = ":mike:"
-      }
+  # - pwsh: |
+  #     $body = @{
+  #       username = "endjin-bot"
+  #       icon_emoji = ":mike:"
+  #     }
 
-      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
-      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
-      Write-Host $packages
+  #     Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+  #     $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
+  #     Write-Host $packages
 
-      $blocks = @()
-      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+  #     $blocks = @()
+  #     $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
 
-      $packagesText = ""
+  #     $packagesText = ""
 
-      foreach ($p in $packages) {
-          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
-          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
-      }
+  #     foreach ($p in $packages) {
+  #         $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+  #         $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+  #     }
 
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
-      $blocks += @{ type = "divider" }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+  #     $blocks += @{ type = "divider" }
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
 
-      $body += @{ blocks = $blocks }
-      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
-      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
-                        -Method Post `
-                        -body (ConvertTo-Json $body -Depth 99) `
-                        -ContentType 'application/json'
-    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-    displayName: Send notification to Slack channel
-    env:
-      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
-      Endjin_Repository_Name: $(Build.Repository.Name)
-      GitVersion_SemVer: $(Endjin_SemVer)
-      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-      BuildPackagesOutputDirName: $(PackagesOutputDirName)
+  #     $body += @{ blocks = $blocks }
+  #     Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+  #     Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+  #                       -Method Post `
+  #                       -body (ConvertTo-Json $body -Depth 99) `
+  #                       -ContentType 'application/json'
+  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  #   displayName: Send notification to Slack channel
+  #   env:
+  #     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+  #     Endjin_Repository_Name: $(Build.Repository.Name)
+  #     GitVersion_SemVer: $(Endjin_SemVer)
+  #     Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+  #     BuildPackagesOutputDirName: $(PackagesOutputDirName)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -325,10 +325,12 @@ jobs:
   - ${{ parameters.postCopyNugetPackages }}
   - ${{ parameters.prePublishReleaseArtifacts }}
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@1
     displayName: 'Publish Release Artifacts'
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)/Release'
+      targetPath: '$(Build.ArtifactStagingDirectory)/Release'
+      artifactType: 'pipeline'
+      artifactName: 'drop'
 
   - ${{ parameters.postPublishReleaseArtifacts }}
 
@@ -374,59 +376,58 @@ jobs:
       command: push
       nuGetFeedType: internal
       publishVstsFeed: 'endjin-nuget-pre-releases'
-      # publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
       versioningScheme: Off
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
-  # - task: NuGetCommand@2
-  #   displayName: 'Publish to nuget.org'
-  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
-  #   inputs:
-  #     command: push
-  #     nuGetFeedType: external
-  #     publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
-  #     versioningScheme: byBuildNumber
-  #     packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
+  - task: NuGetCommand@2
+    displayName: 'Publish to nuget.org'
+    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
+    inputs:
+      command: push
+      nuGetFeedType: external
+      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+      versioningScheme: Off
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
-  # - ${{ parameters.postPublishNugetPackages }}
+  - ${{ parameters.postPublishNugetPackages }}
 
-  # - pwsh: |
-  #     $body = @{
-  #       username = "endjin-bot"
-  #       icon_emoji = ":mike:"
-  #     }
+  - pwsh: |
+      $body = @{
+        username = "endjin-bot"
+        icon_emoji = ":mike:"
+      }
 
-  #     Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
-  #     $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
-  #     Write-Host $packages
+      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
+      Write-Host $packages
 
-  #     $blocks = @()
-  #     $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+      $blocks = @()
+      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
 
-  #     $packagesText = ""
+      $packagesText = ""
 
-  #     foreach ($p in $packages) {
-  #         $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
-  #         $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
-  #     }
+      foreach ($p in $packages) {
+          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+      }
 
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
-  #     $blocks += @{ type = "divider" }
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+      $blocks += @{ type = "divider" }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
 
-  #     $body += @{ blocks = $blocks }
-  #     Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
-  #     Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
-  #                       -Method Post `
-  #                       -body (ConvertTo-Json $body -Depth 99) `
-  #                       -ContentType 'application/json'
-  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-  #   displayName: Send notification to Slack channel
-  #   env:
-  #     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
-  #     Endjin_Repository_Name: $(Build.Repository.Name)
-  #     GitVersion_SemVer: $(Endjin_SemVer)
-  #     Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-  #     BuildPackagesOutputDirName: $(PackagesOutputDirName)
+      $body += @{ blocks = $blocks }
+      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+                        -Method Post `
+                        -body (ConvertTo-Json $body -Depth 99) `
+                        -ContentType 'application/json'
+    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    displayName: Send notification to Slack channel
+    env:
+      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+      Endjin_Repository_Name: $(Build.Repository.Name)
+      GitVersion_SemVer: $(Endjin_SemVer)
+      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+      BuildPackagesOutputDirName: $(PackagesOutputDirName)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -368,54 +368,65 @@ jobs:
   - ${{ parameters.prePublishNugetPackages }}
 
   - task: NuGetCommand@2
-    displayName: 'Publish to nuget.org'
-    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
+    displayName: 'Publish to internal feed'
+    condition: and(succeeded(), and(ne(variables['Endjin.ForcePublish'], 'true'), ne(variables['Endjin_PreReleaseTag'], '')))
     inputs:
       command: push
-      nuGetFeedType: external
-      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
-      versioningScheme: byBuildNumber
+      nuGetFeedType: internal
+      publishVstsFeed: 'endjin-nuget-pre-releases'
+      # publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+      versioningScheme: Off
       packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
-  - ${{ parameters.postPublishNugetPackages }}
+  # - task: NuGetCommand@2
+  #   displayName: 'Publish to nuget.org'
+  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
+  #   inputs:
+  #     command: push
+  #     nuGetFeedType: external
+  #     publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+  #     versioningScheme: byBuildNumber
+  #     packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
-  - pwsh: |
-      $body = @{
-        username = "endjin-bot"
-        icon_emoji = ":mike:"
-      }
+  # - ${{ parameters.postPublishNugetPackages }}
 
-      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
-      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
-      Write-Host $packages
+  # - pwsh: |
+  #     $body = @{
+  #       username = "endjin-bot"
+  #       icon_emoji = ":mike:"
+  #     }
 
-      $blocks = @()
-      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+  #     Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+  #     $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
+  #     Write-Host $packages
 
-      $packagesText = ""
+  #     $blocks = @()
+  #     $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
 
-      foreach ($p in $packages) {
-          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
-          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
-      }
+  #     $packagesText = ""
 
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
-      $blocks += @{ type = "divider" }
-      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+  #     foreach ($p in $packages) {
+  #         $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+  #         $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+  #     }
 
-      $body += @{ blocks = $blocks }
-      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
-      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
-                        -Method Post `
-                        -body (ConvertTo-Json $body -Depth 99) `
-                        -ContentType 'application/json'
-    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-    displayName: Send notification to Slack channel
-    env:
-      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
-      Endjin_Repository_Name: $(Build.Repository.Name)
-      GitVersion_SemVer: $(Endjin_SemVer)
-      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-      BuildPackagesOutputDirName: $(PackagesOutputDirName)
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+  #     $blocks += @{ type = "divider" }
+  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+
+  #     $body += @{ blocks = $blocks }
+  #     Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+  #     Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+  #                       -Method Post `
+  #                       -body (ConvertTo-Json $body -Depth 99) `
+  #                       -ContentType 'application/json'
+  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+  #   displayName: Send notification to Slack channel
+  #   env:
+  #     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+  #     Endjin_Repository_Name: $(Build.Repository.Name)
+  #     GitVersion_SemVer: $(Endjin_SemVer)
+  #     Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+  #     BuildPackagesOutputDirName: $(PackagesOutputDirName)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -60,6 +60,7 @@ jobs:
     # Endjin_Service_Connection_GitHub
     # Endjin_Slack_ReleasesWebhookUri
     # Endjin.ForcePublish
+    # Endjin.InternalPublish
   steps:
   - powershell: |
       if ($env:BUILD_REPOSITORY_PROVIDER -eq "GitHub") {

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -94,11 +94,6 @@ jobs:
 
   - ${{ parameters.postCustomEnvironmentVariables }}
 
-  - powershell: |
-      Write-Host "Initializing $(Build.ArtifactStagingDirectory)/Release"
-      New-Item -Path $(Build.ArtifactStagingDirectory) -Name "Release" -ItemType "directory"
-    displayName: 'Initialize Artifact Staging Release Directory'
-
   # Useful for debugging purposes
   - powershell: 'gci Env:'
     condition: or(variables['Endjin.BuildDiagnostics'], variables['Endjin.ShowEnvironment'])
@@ -173,6 +168,7 @@ jobs:
         htmlPath: '$(RunCompile_with_AzAuth.SbomHtmlReportPath)'
 
   - task: PublishPipelineArtifact@1
+    displayName: Store Compilation Outputs
     inputs:
       targetPath: '$(Build.SourcesDirectory)'
       artifactType: 'pipeline'
@@ -200,6 +196,7 @@ jobs:
       additionalNetSdkVersions: ${{ parameters.additionalNetSdkVersions }}
       includeNetSdkPreviewVersions: ${{ parameters.includeNetSdkPreviewVersions }}
   - task: DownloadPipelineArtifact@2
+    displayName: Retrieve Compilation Outputs
     inputs:
       buildType: 'current'
       artifactName: build
@@ -256,22 +253,19 @@ jobs:
   steps:
   - checkout: self    # ensure we have a git reference to support later tasks
     fetchDepth: 0
-  - pwsh: |
-      ls -la $(Build.SourcesDirectory)
-    displayName: DEBUG - Before artefact download
+
   - template: install-dotnet-sdks.yml
     parameters:
       netSdkVersion: ${{ parameters.netSdkVersion }}
       additionalNetSdkVersions: ${{ parameters.additionalNetSdkVersions }}
       includeNetSdkPreviewVersions: ${{ parameters.includeNetSdkPreviewVersions }}
+
   - task: DownloadPipelineArtifact@2
+    displayName: Retrieve Compilation Outputs
     inputs:
       buildType: 'current'
       artifactName: build
       targetPath: $(Build.SourcesDirectory)
-  - pwsh: |
-      ls -la $(Build.SourcesDirectory)
-    displayName: DEBUG - After artefact download
 
   - ${{ parameters.preCustomEnvironmentVariables }}
 
@@ -373,55 +367,55 @@ jobs:
 
   - ${{ parameters.prePublishNugetPackages }}
 
-  # - task: NuGetCommand@2
-  #   displayName: 'Publish to nuget.org'
-  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
-  #   inputs:
-  #     command: push
-  #     nuGetFeedType: external
-  #     publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
-  #     versioningScheme: byBuildNumber
-  #     packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
+  - task: NuGetCommand@2
+    displayName: 'Publish to nuget.org'
+    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')))
+    inputs:
+      command: push
+      nuGetFeedType: external
+      publishFeedCredentials: ${{ parameters.service_connection_nuget_org }}
+      versioningScheme: byBuildNumber
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/Release/**/*.nupkg'
 
   - ${{ parameters.postPublishNugetPackages }}
 
-  # - pwsh: |
-  #     $body = @{
-  #       username = "endjin-bot"
-  #       icon_emoji = ":mike:"
-  #     }
+  - pwsh: |
+      $body = @{
+        username = "endjin-bot"
+        icon_emoji = ":mike:"
+      }
 
-  #     Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
-  #     $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
-  #     Write-Host $packages
+      Write-Host "Build_ArtifactStagingDirectory: $($env:Build_ArtifactStagingDirectory)"
+      $packages = gci -Recurse -Filter *.nupkg -Path "$($env:Build_ArtifactStagingDirectory)/Release/NuGet/$($env:BuildPackagesOutputDirName)"
+      Write-Host $packages
 
-  #     $blocks = @()
-  #     $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
+      $blocks = @()
+      $blocks += @{ type = "header"; text = @{ type = "plain_text";  text = "New release for $($env:Endjin_Repository_Name) : $($env:GitVersion_SemVer)" } }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The following packages have been published to <https://nuget.org|NuGet>:" } }
 
-  #     $packagesText = ""
+      $packagesText = ""
 
-  #     foreach ($p in $packages) {
-  #         $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
-  #         $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
-  #     }
+      foreach ($p in $packages) {
+          $packageName = [IO.Path]::GetFileNameWithoutExtension($p.Name) -replace ".$($env:GitVersion_SemVer)",""
+          $packagesText += "•  <https://nuget.org/packages/$packageName/$($env:GitVersion_SemVer)|$packageName>`n"
+      }
 
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
-  #     $blocks += @{ type = "divider" }
-  #     $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = $packagesText } }
+      $blocks += @{ type = "divider" }
+      $blocks += @{ type = "section"; text = @{ type = "mrkdwn";  text = "The GitHub release can be found <https://github.com/$($env:Endjin_Repository_Name)/releases/tag/$($env:GitVersion_SemVer)|here>" } }
 
-  #     $body += @{ blocks = $blocks }
-  #     Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
-  #     Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
-  #                       -Method Post `
-  #                       -body (ConvertTo-Json $body -Depth 99) `
-  #                       -ContentType 'application/json'
-  #   condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
-  #   displayName: Send notification to Slack channel
-  #   env:
-  #     Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
-  #     Endjin_Repository_Name: $(Build.Repository.Name)
-  #     GitVersion_SemVer: $(Endjin_SemVer)
-  #     Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
-  #     BuildPackagesOutputDirName: $(PackagesOutputDirName)
+      $body += @{ blocks = $blocks }
+      Write-Host "body:`n$(ConvertTo-Json $body -Depth 99)"
+      Invoke-RestMethod -uri "$($env:Endjin_Slack_ReleasesWebhookUri)" `
+                        -Method Post `
+                        -body (ConvertTo-Json $body -Depth 99) `
+                        -ContentType 'application/json'
+    condition: and(succeeded(), or(eq(variables['Endjin.ForcePublish'], 'true'), eq(variables['Endjin_PreReleaseTag'], '')), ne(variables['Endjin_Slack_ReleasesWebhookUri'], ''))
+    displayName: Send notification to Slack channel
+    env:
+      Endjin_Slack_ReleasesWebhookUri: $(Endjin_Slack_ReleasesWebhookUri)
+      Endjin_Repository_Name: $(Build.Repository.Name)
+      GitVersion_SemVer: $(Endjin_SemVer)
+      Build_ArtifactStagingDirectory: $(Build.ArtifactStagingDirectory)
+      BuildPackagesOutputDirName: $(PackagesOutputDirName)
       

--- a/templates/build.and.release.scripted.yml
+++ b/templates/build.and.release.scripted.yml
@@ -346,12 +346,14 @@ jobs:
       Write-Host "Repository Name: '$($env:BUILD_REPOSITORY_NAME)'"
       Write-Host "Endjin_SemVer: '$($env:Endjin_SemVer)'"
       Write-Host "Endjin.ForcePublish: '$($env:Endjin_ForcePublish)'"
+      Write-Host "Endjin.InternalPublish: '$($env:Endjin_InternalPublish)'"
       Write-Host "Endjin_PreReleaseTag: '$($env:Endjin_PreReleaseTag)'"
       Write-Host "Endjin_IsPreRelease: '$($env:Endjin_IsPreRelease)'"
     displayName: Debug release condition parameters
     env:
       Endjin_SemVer: $(Endjin_SemVer)
       Endjin_ForcePublish: ${{ variables['Endjin.ForcePublish'] }}
+      Endjin_InternalPublish: ${{ variables['Endjin.InternalPublish'] }}
       Endjin_PreReleaseTag: $(Endjin_PreReleaseTag)
       Endjin_IsPreRelease: $(Endjin_IsPreRelease)
 


### PR DESCRIPTION
Resolves an issue whereby GitHub releases were always being created as `prerelease`.

Also adds an optional step to publish to an internal feed (when not publishing to NuGet.org) so we have an easier way to diagnose publishing-related issues.

This is enabled by setting the Azure Pipelines variable `Endjin.InternalPublish` to `true`